### PR TITLE
Add gitattributes and gitmodules as git icons.

### DIFF
--- a/fileicons/1ct-icon-theme.json
+++ b/fileicons/1ct-icon-theme.json
@@ -676,6 +676,8 @@
 "vscodeignore": "vsc",
 "download":"download",
 "gitignore":"gitignore",
+"gitattributes":"git",
+"gitmodules":"git",
 "ico":"ico",
 "dll":"cog",
 "config": "cog",


### PR DESCRIPTION
This does not add any icon images, but accociates `.gitattributes` and `.gitmodules` with the git icon.

![image](https://user-images.githubusercontent.com/24465214/101976612-d4ac3480-3c14-11eb-99ec-2337f8fa2cfe.png)
